### PR TITLE
Fix empty listValue on commands

### DIFF
--- a/core/class/fullyKiosK.class.php
+++ b/core/class/fullyKiosK.class.php
@@ -1342,7 +1342,7 @@ Constant Value: 0 (0x00000000)
 
 				$fullyKiosKCmd->setConfiguration('cmd', $params['cmd'] ?: null);
 
-				$fullyKiosKCmd->setConfiguration('listValue', json_encode($params['listValue']) ?: null);
+				$fullyKiosKCmd->setConfiguration('listValue', json_encode($params['listValue']) ?: '');
 
 				$fullyKiosKCmd->setDisplay('forceReturnLineBefore', $params['forceReturnLineBefore'] ?: false);
 	                        $fullyKiosKCmd->setDisplay('message_disable', $params['message_disable'] ?: false);
@@ -1375,7 +1375,7 @@ Constant Value: 0 (0x00000000)
 
 				$fullyKiosKCmd->setConfiguration('cmd', $params['cmd'] ?: null);
 
-				$fullyKiosKCmd->setConfiguration('listValue', json_encode($params['listValue']) ?: null);
+				$fullyKiosKCmd->setConfiguration('listValue', json_encode($params['listValue']) ?: '');
 
 				$fullyKiosKCmd->setDisplay('forceReturnLineBefore', $params['forceReturnLineBefore'] ?: false);
 	                        $fullyKiosKCmd->setDisplay('message_disable', $params['message_disable'] ?: false);


### PR DESCRIPTION
When fullyKiosk equipment is displayed on dashboard, the following line is generated in http.error log file :
`PHP Notice:  Undefined offset: 1 in /var/www/html/core/class/cmd.class.php on line 1298, referer: https://xxxxxxx/index.php?v=d&p=dashboard&object_id=16`

It's because when there is no listValue on command, the value is set to null.
In core/class/cmd.class.php file 1282 there is this condition :
`if ($this->getConfiguration('listValue', '') != '') {`
that test empty string only but not null value which cause the error some lines after.

fullyKiosK : 2019-12-04 06:35:34
Jeedom : 4.0.38