### PR TITLE
Update for version 1.42.2/4 of FullyKiosk - isScreenOn <-> screenOn

### DIFF
--- a/core/class/fullyKiosK.class.php
+++ b/core/class/fullyKiosK.class.php
@@ -767,7 +767,7 @@ public static function initInfosMap(){
 						'type' => 'info',
 						'subtype' => 'binary',
 						'isvisible' => 1,
-						'restkey' => 'isScreenOn',
+						'restkey' => 'screenOn',
 
 					),
 					'keyguardLocked' => array(

--- a/core/class/fullyKiosK.class.php
+++ b/core/class/fullyKiosK.class.php
@@ -767,7 +767,7 @@ public static function initInfosMap(){
 						'type' => 'info',
 						'subtype' => 'binary',
 						'isvisible' => 1,
-						'restkey' => 'screenOn',
+						'restkey' => array('screenOn', 'isScreenOn'),
 
 					),
 					'keyguardLocked' => array(
@@ -1257,20 +1257,31 @@ public static function initInfosMap(){
 
 				//update cmdinfo value
 				foreach(self::$_infosMap as $cmdLogicalId=>$params)
-				{
-					if(isset($params['restkey'], $json[$params['restkey']]))
+				{	
+					if(!isset($params['restkey']))continue;
+
+					if(!is_array($params['restkey'])){
+						if(!isset($json[$params['restkey']]))continue;// si string et que pas défini ds le json on continue
+
+						$value = $json[$params['restkey']];
+					}else{// c'est un array
+						foreach($subParam as $restKey){// on cherche parmi toutes les valeurs si une existe 
+							if(isset($json[$restKey])){// siexiste ds le jsopn
+								$value = $json[$restKey];// on valorise la valeur
+								continue;//on sort de la boucle
+							}
+						}
+					}
+
+					if(isset($value))// si on a trouvé une valeur au dessus correspondant à un eentrée du json
 					{
 						//log::add('fullyKiosK', 'debug',  __METHOD__.' '.__LINE__.' '.$cmdLogicalId.' => '.json_encode($json[$params['restkey']]));
-						$value = $json[$params['restkey']];
 						str_replace("\\n", " ", $value);
 						if(isset($params['cbTransform']) && is_callable($params['cbTransform']))
 						{
 							$value = call_user_func($params['cbTransform'], $value);
 							//log::add('fullyKiosK', 'debug', __METHOD__.' '.__LINE__.' Transform to => '.json_encode($value));
 						}
-
-
-
 						$this->checkAndUpdateCmd($cmdLogicalId,$value);
 					}
 				}

--- a/core/class/fullyKiosK.class.php
+++ b/core/class/fullyKiosK.class.php
@@ -767,7 +767,7 @@ public static function initInfosMap(){
 						'type' => 'info',
 						'subtype' => 'binary',
 						'isvisible' => 1,
-						'restkey' => array('screenOn', 'isScreenOn'),// pour les différentes version, à partir de 1.42.2 => isScreenOn est passé à screenOn
+						'restkey' => array('isScreenOn', 'screenOn'),// pour les différentes version, à partir de 1.42.2 => isScreenOn est passé à screenOn
 
 					),
 					'keyguardLocked' => array(
@@ -1262,10 +1262,11 @@ public static function initInfosMap(){
 
 					if(!is_array($params['restkey'])){
 						if(!isset($json[$params['restkey']]))continue;// si string et que pas défini ds le json on continue
-
+						
 						$value = $json[$params['restkey']];
 					}else{// c'est un array
-						foreach($subParam as $restKey){// on cherche parmi toutes les valeurs si une existe 
+						log::add('fullyKiosK', 'debug', $cmdLogicalId.' is an array '.implode(',',$params['restkey']));
+						foreach($params['restkey'] as $restKey){// on cherche parmi toutes les valeurs si une existe 
 							if(isset($json[$restKey])){// siexiste ds le jsopn
 								$value = $json[$restKey];// on valorise la valeur
 								continue;//on sort de la boucle

--- a/core/class/fullyKiosK.class.php
+++ b/core/class/fullyKiosK.class.php
@@ -767,7 +767,7 @@ public static function initInfosMap(){
 						'type' => 'info',
 						'subtype' => 'binary',
 						'isvisible' => 1,
-						'restkey' => array('screenOn', 'isScreenOn'),
+						'restkey' => array('screenOn', 'isScreenOn'),// pour les différentes version, à partir de 1.42.2 => isScreenOn est passé à screenOn
 
 					),
 					'keyguardLocked' => array(


### PR DESCRIPTION
Hi sebsst, 

This is a proposal to handle the change of rest key on v 1.42.2/4. 

We have identified the parameter of[ screen status ](https://community.jeedom.com/t/fullykiosk-pas-de-remontee-dinfos-dans-jeedom/38994/16)for whom rest key has change from isScreenOn to screenOn.

=> I've had an array as restkey definition for retrocompatibility (containing both 'isScreenOn' and 'screenOn') and so some changes to the function that handle the json from the app.

I do not try to assess fully version as the information was return together with the screen status definition.

I've tested on fullyk v 1.42.4 and 1.39

